### PR TITLE
borg create support

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,6 +105,22 @@ or
 
     $ ./find.sh ~/projects/ | ./find2flat.py - | ./unflatten.py - | ncdu -f -
 
+### Borg export
+
+`borg.sh` allows you to turn the `borg create --dry-run --list` output into an
+ncdu-compatible JSON format. This allows you to preview the directories which
+borg would back up using ncdu's interactive, discoverable front-end. Unlike the
+`find` export however, borg and the python script must be ran as the same user
+on the same machine for this to work.
+
+    $ ./borg.sh /path/to/borg/repo::{now} /path/to/back/up/ > borg-flat-export.json
+    $ ./unflatten.py borg-flat-export.json > borg-export.json
+    $ ncdu -f borg-export.json
+
+or
+
+    $ ./borg.sh /path/to/borg/repo::{now} /path/to/back/up/ | ./unflatten.py - | ncdu -f -
+
 ## Graph of tools
 
 

--- a/README.md
+++ b/README.md
@@ -125,29 +125,29 @@ or
 
 
                          .------------.
-         .---------------| filesystem |
-         |               '------------'
-         |                      |
-         |                      | ncdu -o / ncdu-export
-         |                      v
-         |                  .------.         .---------.
-         | find.sh          | ncdu | ncdu -f |  ncdu   |
-         |                  | JSON |-------->| preview |
-         |                  '------'         '---------'
-         |                    |  ^
-         |         flatten.py |  | unflatten.py
-         v                    v  |
+      .----.-------------| filesystem |
+      |    |             '------------'
+      |    |                    |
+      |    |                    | ncdu -o / ncdu-export
+      |    |                    v
+      |    |                .------.         .---------.
+      |    | find.sh        | ncdu | ncdu -f |  ncdu   |
+      |    |                | JSON |-------->| preview |
+      |    |                '------'         '---------'
+      |    |                  |  ^
+      |    |       flatten.py |  | unflatten.py
+      |    v                  v  |
     .--------.              .------.
     |  find  | find2flat.py | flat |<---. jq filtering
     | output |------------->| JSON |----'
     '--------'              '------'
-                                |
-                                | jq
-                                v
-                          .-----------.        .---------.
-                          |    tar    | tar -T |   tar   |
-                          | file list |------->| archive |
-                          '-----------'        '---------'
+      |                       ^  |
+      |                       |  | jq
+      v                       |  v
+    .---------.               |  .-----------.        .---------.
+    | borg.sh |---------------'  |    tar    | tar -T |   tar   |
+    | output  |                  | file list |------->| archive |
+    '---------'                  '-----------'        '---------'
 
 
 

--- a/borg.sh
+++ b/borg.sh
@@ -1,0 +1,4 @@
+#!/bin/sh
+
+# Runs `borg create` with the required flags and pipe stderr to borg2flat
+exec borg create --dry-run --list "$@" 2>&1 | $(dirname "$0")/borg2flat.py /dev/stdin

--- a/borg2flat.py
+++ b/borg2flat.py
@@ -1,0 +1,26 @@
+#!/usr/bin/env python3
+
+import os
+import argparse
+import json
+import stat
+
+def getFileInfo(path):
+    stats = os.lstat(path)
+    dirname = os.path.dirname(path)
+
+    return {
+        "name" : os.path.basename(path),
+        "asize" : stats.st_size,
+        "dsize" : stats.st_blocks * 512,
+        "ino" : stats.st_ino,
+        "mtime" : int(stats.st_mtime),
+        "type" : "dir" if os.path.isdir(path) else "file",
+        "dirs" : f"<root>/{dirname}" if dirname else "<root>",
+    }
+
+parser = argparse.ArgumentParser()
+parser.add_argument('filename')
+args = parser.parse_args()
+
+print(json.dumps(getFileInfo(args.filename)))

--- a/borg2flat.py
+++ b/borg2flat.py
@@ -27,4 +27,5 @@ args = p.parse_args()
 args.root = args.root.rstrip("/")
 
 for line in args.file:
-    print(json.dumps(getFileInfo(line[:-1], args.root)))
+    filename = line.rstrip("\n")
+    print(json.dumps(getFileInfo(filename, args.root)))

--- a/borg2flat.py
+++ b/borg2flat.py
@@ -45,4 +45,4 @@ for line in args.file:
 
     filename = line[2:].rstrip("\n")
     excluded = line[0] in exclusion_letters
-    print(json.dumps(getFileInfo(filename, args.root, excluded)))
+    print(json.dumps(getFileInfo(filename, args.root, excluded), ensure_ascii = False))

--- a/borg2flat.py
+++ b/borg2flat.py
@@ -21,9 +21,10 @@ def getFileInfo(path, root):
 
 p = argparse.ArgumentParser()
 p.add_argument("--root", default="<root>", help="root directory name")
-p.add_argument("filename", help="find export filename")
+p.add_argument("file", type=argparse.FileType("r"), help="find export filename")
 args = p.parse_args()
 
 args.root = args.root.rstrip("/")
 
-print(json.dumps(getFileInfo(args.filename, args.root)))
+for line in args.file:
+    print(json.dumps(getFileInfo(line[:-1], args.root)))

--- a/borg2flat.py
+++ b/borg2flat.py
@@ -5,7 +5,7 @@ import argparse
 import json
 import stat
 
-def getFileInfo(path):
+def getFileInfo(path, root):
     stats = os.lstat(path)
     dirname = os.path.dirname(path)
 
@@ -16,11 +16,14 @@ def getFileInfo(path):
         "ino" : stats.st_ino,
         "mtime" : int(stats.st_mtime),
         "type" : "dir" if os.path.isdir(path) else "file",
-        "dirs" : f"<root>/{dirname}" if dirname else "<root>",
+        "dirs" : f"{root}/{dirname}" if dirname else root,
     }
 
-parser = argparse.ArgumentParser()
-parser.add_argument('filename')
-args = parser.parse_args()
+p = argparse.ArgumentParser()
+p.add_argument("--root", default="<root>", help="root directory name")
+p.add_argument("filename", help="find export filename")
+args = p.parse_args()
 
-print(json.dumps(getFileInfo(args.filename)))
+args.root = args.root.rstrip("/")
+
+print(json.dumps(getFileInfo(args.filename, args.root)))

--- a/borg2flat.py
+++ b/borg2flat.py
@@ -24,7 +24,7 @@ def getFileInfo(path, root, is_excluded = False):
 
 p = argparse.ArgumentParser()
 p.add_argument("--root", default="<root>", help="root directory name")
-p.add_argument("file", type=argparse.FileType("r"), help="find export filename")
+p.add_argument("file", type=argparse.FileType("r"), help="borg export filename")
 args = p.parse_args()
 
 args.root = args.root.rstrip("/")

--- a/borg2flat.py
+++ b/borg2flat.py
@@ -5,7 +5,7 @@ import argparse
 import json
 import stat
 
-def getFileInfo(path, root):
+def getFileInfo(path, root, is_excluded = False):
     stats = os.lstat(path)
     dirname = os.path.dirname(path)
 
@@ -17,7 +17,9 @@ def getFileInfo(path, root):
         "mtime" : int(stats.st_mtime),
         "type" : "dir" if os.path.isdir(path) else "file",
         "dirs" : f"{root}/{dirname}" if dirname else root,
-    }
+    } | ({
+        "excluded" : "pattern",
+    } if is_excluded else { })
 
 p = argparse.ArgumentParser()
 p.add_argument("--root", default="<root>", help="root directory name")

--- a/borg2flat.py
+++ b/borg2flat.py
@@ -15,7 +15,7 @@ def getFileInfo(path, root, is_excluded = False):
         "dsize" : stats.st_blocks * 512,
         "ino" : stats.st_ino,
         "mtime" : int(stats.st_mtime),
-        "type" : "dir" if os.path.isdir(path) else "file",
+        "type" : "dir" if os.path.isdir(path) and not is_excluded else "file",
         "dirs" : f"{root}/{dirname}" if dirname else root,
     } | ({
         "excluded" : "pattern",


### PR DESCRIPTION
A use-case of mine is that I want to be able to preview what a `borg create` run would do but `borg` has a bespoke `--exclude` implementation that differs from `ncdu`'s and also has support for custom exclusion/inclusion patterns that cannot be easily replicated in `ncdu`.

This adds `borg2flat.py` to generate a flattened JSON from `borg`'s own `borg create --list` output which applies all of its custom exclusion patterns.