### PR TITLE
(un)flatten: don't convert JSON strings to ascii

### DIFF
--- a/flatten.py
+++ b/flatten.py
@@ -91,7 +91,7 @@ for prefix, event, value in parser:
         if state != ParserState.HEADER:
             # output meta-data (omit header)
             obj["dirs"] = dirs if options.dirs == "array" else "/".join(dirs)
-            print(json.dumps(obj))
+            print(json.dumps(obj, ensure_ascii = False))
 
         if state == ParserState.FIRST_MAP:
             # entered a directory, expand path for its entries

--- a/unflatten.py
+++ b/unflatten.py
@@ -54,7 +54,7 @@ def adjust_depth(dirs, prev_dirs):
         print("]"*closed, end="")
     if opened:
         for opened_dir in dirs[-opened:]:
-            print(""",\n[{{"name":{},"asize":0,"dsize":0,"ino":0,"mtime":0}}""".format(json.dumps(opened_dir)), end="")
+            print(""",\n[{{"name":{},"asize":0,"dsize":0,"ino":0,"mtime":0}}""".format(json.dumps(opened_dir, ensure_ascii = False)), end="")
 
 for line in options.file:
     obj = json.loads(line)
@@ -67,10 +67,10 @@ for line in options.file:
     del obj["type"]
     adjust_depth(dirs, prev_dirs)
     if etype == "dir":
-        print(",\n[{}".format(json.dumps(obj)), end="")
+        print(",\n[{}".format(json.dumps(obj, ensure_ascii = False)), end="")
         dirs.append(obj["name"])
     else:
-        print(",\n{}".format(json.dumps(obj)), end="")
+        print(",\n{}".format(json.dumps(obj, ensure_ascii = False)), end="")
     prev_dirs = dirs
 
 dirs = []


### PR DESCRIPTION
Successfully runs:

    ./find.sh . | ./find2flat.py - | ./unflatten.py - | ./flatten.py - | ./unflatten.py - | ncdu -f - -0

In a directory containing a file and directory with emoji filename.

Fixes https://github.com/wodny/ncdu-export/issues/5